### PR TITLE
Remove empty fields from output

### DIFF
--- a/lib/backend.ml
+++ b/lib/backend.ml
@@ -103,8 +103,6 @@ module Benchmark_metric = struct
     name : string;
     mutable value : int list;
     units : string;
-    description : string;
-    trend : string option;
   }
   [@@deriving yojson_of]
 end
@@ -432,8 +430,6 @@ module Benchmark = struct
         Benchmark_metric.name = Merlin.Query_type.to_string query_type;
         value = [ max_timing ];
         units = "ms";
-        description = "";
-        trend = None;
       }
     in
     (* TODO: Pass it instead of hardcoding *)

--- a/test/bench.t/run.t
+++ b/test/bench.t/run.t
@@ -15,9 +15,7 @@
               0,
               0
             ],
-            "units": "ms",
-            "description": "",
-            "trend": null
+            "units": "ms"
           },
           {
             "name": "complete-prefix",
@@ -26,9 +24,7 @@
               0,
               0
             ],
-            "units": "ms",
-            "description": "",
-            "trend": null
+            "units": "ms"
           },
           {
             "name": "errors",
@@ -36,9 +32,7 @@
               0,
               0
             ],
-            "units": "ms",
-            "description": "",
-            "trend": null
+            "units": "ms"
           },
           {
             "name": "expand-prefix",
@@ -47,9 +41,7 @@
               0,
               0
             ],
-            "units": "ms",
-            "description": "",
-            "trend": null
+            "units": "ms"
           },
           {
             "name": "locate",
@@ -58,9 +50,7 @@
               0,
               0
             ],
-            "units": "ms",
-            "description": "",
-            "trend": null
+            "units": "ms"
           },
           {
             "name": "occurrences",
@@ -69,9 +59,7 @@
               0,
               0
             ],
-            "units": "ms",
-            "description": "",
-            "trend": null
+            "units": "ms"
           },
           {
             "name": "type-enclosing",
@@ -81,9 +69,7 @@
               0,
               0
             ],
-            "units": "ms",
-            "description": "",
-            "trend": null
+            "units": "ms"
           }
         ]
       }


### PR DESCRIPTION
There is no purpose in keeping them empty, so let's make the output shorter.