### PR TITLE
Create state based on filename instead of full path

### DIFF
--- a/lib/file.ml
+++ b/lib/file.ml
@@ -4,7 +4,7 @@ type t = Fpath.t
 
 let yojson_of_t file = `String (Fpath.to_string file)
 let pp = Fpath.pp
-let filename = Fpath.to_string
+let filename = Fpath.filename
 
 let get_files ~extensions paths =
   let open Result.Syntax in


### PR DESCRIPTION
Full path varies between environments (e.g. CI vs dev machine). By using filename we get real determinism. Also, we get consistent interface (File.filename will return actual filename, and not full path)