### PR TITLE
Sort filepaths for reproducibility

### DIFF
--- a/lib/file.ml
+++ b/lib/file.ml
@@ -35,7 +35,7 @@ let get_files ~extensions paths =
           (String.concat ", " extensions)
       in
       Error (`Msg msg)
-  | _ -> Ok files
+  | _ -> Ok (List.sort Fpath.compare files)
 
 let parse_impl sourcefile =
   let file = Fpath.to_string sourcefile in

--- a/lib/file.mli
+++ b/lib/file.mli
@@ -9,7 +9,7 @@ val filename : t -> string
 
 val get_files :
   extensions:string list -> Fpath.t list -> (t list, Rresult.R.msg) result
-(** [get_files ~extension dir] produces the list of all files with extension
+(** [get_files ~extension dir] produces sorted list of all files with extension
     [extension] inside [dir] *)
 
 val parse_impl : t -> Ppxlib.Parsetree.structure


### PR DESCRIPTION
When running tests locally and in CI, I get issues with different results order. We use `Bos.OS.Path.fold` to traverse the files, and it doesn't seem to have any guarantees about determinism. Sorting by path seems like a good solution.