### PR TITLE
Fix overlapping ids

### DIFF
--- a/lib/workflows.ml
+++ b/lib/workflows.ml
@@ -58,7 +58,7 @@ let analyze ~backend:(module Backend : Backend.Data_tables) ~repeats
                   })
           merlins
       in
-      id_counter
+      id_counter + 1
     else
       match Samples.generate ~sample_size ~id_counter file query_type with
       | None ->

--- a/test/error_regression.t/run.t
+++ b/test/error_regression.t/run.t
@@ -4,9 +4,14 @@ TODO     stderr:
 /bin/sh: -c: line 0: syntax error near unexpected token `('
 /bin/sh: -c: line 0: `ocamlmerlin server expand-prefix -prefix ( + -position '3:12' -filename /Users/rafal/Projects/Tarides/merl-an/_build/default/test/error_regression.t/test.ml < /Users/rafal/Projects/Tarides/merl-an/_build/default/test/error_regression.t/test.ml'
 
-  $ merl-an error-regression -s 1 -p test.ml --data=test-data 2>/dev/null
+  $ merl-an error-regression -s 1 -p test.ml,test1.ml --data=test-data 2>/dev/null
 
   $ cat test-data/results.json
+  {"sample_id":13,"merlin_id":0,"cmd":"ocamlmerlin server errors -filename test1.ml < test1.ml","success":true}
+  {"sample_id":12,"merlin_id":0,"cmd":" ocamlmerlin server locate -look-for ml -position '3:12' -index 0 -filename test1.ml < test1.ml","success":true}
+  {"sample_id":9,"merlin_id":0,"cmd":"ocamlmerlin server occurrences -identifier-at '3:12' -filename test1.ml < test1.ml","success":true}
+  {"sample_id":8,"merlin_id":0,"cmd":"ocamlmerlin server type-enclosing -position '1:8' -filename test1.ml < test1.ml","success":true}
+  {"sample_id":7,"merlin_id":0,"cmd":"ocamlmerlin server case-analysis -start '1:8' -end '1:8' -filename test1.ml < test1.ml","success":true}
   {"sample_id":6,"merlin_id":0,"cmd":"ocamlmerlin server errors -filename test.ml < test.ml","success":true}
   {"sample_id":5,"merlin_id":0,"cmd":" ocamlmerlin server locate -look-for ml -position '3:12' -index 0 -filename test.ml < test.ml","success":true}
   {"sample_id":2,"merlin_id":0,"cmd":"ocamlmerlin server occurrences -identifier-at '3:12' -filename test.ml < test.ml","success":true}

--- a/test/error_regression.t/test1.ml
+++ b/test/error_regression.t/test1.ml
@@ -1,0 +1,3 @@
+let x = 1
+
+let f y = y + 3


### PR DESCRIPTION
This PR fixes overlapping ids that are created when using "global" merlin queries.
Modified error_regression without this patch would look like this:
```json
  {"sample_id":12,"merlin_id":0,"cmd":"ocamlmerlin server errors -filename test1.ml < test1.ml","success":true}
  {"sample_id":11,"merlin_id":0,"cmd":" ocamlmerlin server locate -look-for ml -position '3:12' -index 0 -filename test1.ml < test1.ml","success":true}
  {"sample_id":8,"merlin_id":0,"cmd":"ocamlmerlin server occurrences -identifier-at '3:12' -filename test1.ml < test1.ml","success":true}
  {"sample_id":7,"merlin_id":0,"cmd":"ocamlmerlin server type-enclosing -position '1:8' -filename test1.ml < test1.ml","success":true}
  {"sample_id":6,"merlin_id":0,"cmd":"ocamlmerlin server case-analysis -start '1:8' -end '1:8' -filename test1.ml < test1.ml","success":true}
  {"sample_id":6,"merlin_id":0,"cmd":"ocamlmerlin server errors -filename test.ml < test.ml","success":true}
  {"sample_id":5,"merlin_id":0,"cmd":" ocamlmerlin server locate -look-for ml -position '3:12' -index 0 -filename test.ml < test.ml","success":true}
  {"sample_id":2,"merlin_id":0,"cmd":"ocamlmerlin server occurrences -identifier-at '3:12' -filename test.ml < test.ml","success":true}
  {"sample_id":1,"merlin_id":0,"cmd":"ocamlmerlin server type-enclosing -position '3:12' -filename test.ml < test.ml","success":true}
  {"sample_id":0,"merlin_id":0,"cmd":"ocamlmerlin server case-analysis -start '3:14' -end '3:14' -filename test.ml < test.ml","success":true}
```

Where "sample_id":6 is used twice in two different files. After this patch, it behaves correctly:
```json
  {"sample_id":7,"merlin_id":0,"cmd":"ocamlmerlin server case-analysis -start '1:8' -end '1:8' -filename test1.ml < test1.ml","success":true}
  {"sample_id":6,"merlin_id":0,"cmd":"ocamlmerlin server errors -filename test.ml < test.ml","success":true}
```
See error_regression.t/run.t for full output


