### PR TITLE
Improve the [behavior] cmd

### DIFF
--- a/bin/args.ml
+++ b/bin/args.ml
@@ -104,3 +104,24 @@ let repeats_per_sample =
   named
     (fun x -> `Repeats x)
     Arg.(value & opt int 10 & info [ "repeats"; "r" ] ~doc)
+
+let no_full =
+  let doc = "Don't dump the full Merlin response for each Merlin query." in
+  named
+    (fun x -> `No_full x)
+    Arg.(value & opt bool false & info [ "no-full" ] ~doc)
+
+let no_return_class =
+  let doc = "Don't dump the return class of each Merlin query specifically." in
+  named
+    (fun x -> `No_return_class x)
+    Arg.(value & opt bool false & info [ "no-return-class" ] ~doc)
+
+let no_crash_info =
+  let doc =
+    "Don't dump specific info on whether Merlin has crashed between two \
+     queries."
+  in
+  named
+    (fun x -> `No_crash_info x)
+    Arg.(value & opt bool false & info [ "no-crash-info" ] ~doc)

--- a/bin/args.mli
+++ b/bin/args.mli
@@ -39,3 +39,19 @@ val extensions : [> `Extensions of string list ] Term.t
 val repeats_per_sample : [> `Repeats of int ] Term.t
 (** Number of times you want the same query to be run on the same sample. The
     higher that number, the better to analyze variance. Defaults to 10.*)
+
+val no_full : [> `No_full of bool ] Term.t
+(** In [behavior] cmd, configures whether the whole Merlin response of each
+    query will be dumped. *)
+
+val no_return_class : [> `No_return_class of bool ] Term.t
+(** In [behavior] cmd, configures whether the the following simplification of
+    the Merlin response of each query will be dumped: Dump whether the return
+    class of the response is a [return] containing a message, a return
+    containing a JSON, a [failure], an [error], or an [exception]. *)
+
+val no_crash_info : [> `No_crash_info of bool ] Term.t
+(** In [behavior] cmd, configures whether the the following simplification of
+    the Merlin response of each query will be dumped: Dump whether the return
+    class of the response is a [return] containing a message, a return
+    containing a JSON, a [failure], an [error], or an [exception]. *)

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -44,16 +44,26 @@ let performance =
   in
   Cmd.v info performance_term
 
-let regression =
-  let backend =
-    (module Merl_an.Backend.Regression : Merl_an.Backend.Data_tables)
+let behavior =
+  let f (`No_full no_full) (`No_return_class no_return_class)
+      (`No_crash_info no_crash_info) =
+    let config =
+      {
+        Merl_an.Backend.full = not no_full;
+        return_class = not no_return_class;
+        crash_info = not no_crash_info;
+      }
+    in
+    let backend = Merl_an.Backend.behavior config in
+    analyze ~backend (`Repeats 1)
+      (`Cache [ Merl_an.Merlin.Cache_workflow.Buffer_typed ])
   in
-  let regression_term =
+  let pre_term =
+    Term.(const f $ Args.no_full $ Args.no_return_class $ Args.no_crash_info)
+  in
+  let behavior_term =
     Term.(
-      const
-        (analyze ~backend (`Repeats 1)
-           (`Cache [ Merl_an.Merlin.Cache_workflow.Buffer_typed ]))
-      $ Args.merlin $ Args.proj_dirs $ Args.dir_name $ Args.sample_size
+      pre_term $ Args.merlin $ Args.proj_dirs $ Args.dir_name $ Args.sample_size
       $ Args.query_types $ Args.extensions)
   in
   let info =
@@ -62,36 +72,12 @@ let regression =
        The data is pure in the sense that if you run the command twice with \
        the same input, the created data will be the same. To produce pure \
        data, the [timing] component of the merlin response is being cropped. \
-       This command is useful for end-to-end regression analyzis of the \
+       This command is useful for end-to-end behavior analyzis of the \
        ocamlmerlin responses. "
     in
-    Cmd.info "regression" ~doc ~man
+    Cmd.info "behavior" ~doc ~man
   in
-  Cmd.v info regression_term
-
-let error_regression =
-  let backend =
-    (module Merl_an.Backend.Error_regression : Merl_an.Backend.Data_tables)
-  in
-  let regression_term =
-    Term.(
-      const
-        (analyze ~backend (`Repeats 1)
-           (`Cache [ Merl_an.Merlin.Cache_workflow.Buffer_typed ]))
-      $ Args.merlin $ Args.proj_dirs $ Args.dir_name $ Args.sample_size
-      $ Args.query_types $ Args.extensions)
-  in
-  let info =
-    let doc =
-      "Create a new pure data set to analyze ocamlmerlin on a given project. \
-       The data is pure in the sense that if you run the command twice with \
-       the same input, the created data will be the same. To produce pure \
-       data, the [timing] component of the merlin response is being cropped. \
-       This command reports successful queries"
-    in
-    Cmd.info "error-regression" ~doc ~man
-  in
-  Cmd.v info regression_term
+  Cmd.v info behavior_term
 
 let benchmark =
   let backend =
@@ -113,6 +99,6 @@ let benchmark =
 
 let main =
   Cmd.group ~default:performance_term (Cmd.info "merl-an" ~man)
-    [ performance; error_regression; regression; benchmark ]
+    [ performance; behavior; benchmark ]
 
 let () = exit (Cmd.eval main)

--- a/lib/backend.mli
+++ b/lib/backend.mli
@@ -44,8 +44,9 @@ end
 module Performance : Data_tables
 (** The backend for analyzing [merlin]'s performance. *)
 
-module Regression : Data_tables
+type behavior_config = { full : bool; return_class : bool; crash_info : bool }
+
+val behavior : behavior_config -> (module Data_tables)
 (** The backend for testing possible end-to-end [merlin] regressions. *)
 
-module Error_regression : Data_tables
 module Benchmark : Data_tables

--- a/lib/merlin.mli
+++ b/lib/merlin.mli
@@ -77,6 +77,11 @@ module Response : sig
 
   val yojson_of_t : t -> Yojson.Safe.t
 
+  type value_class = Msg of string | Empty | Other
+  type return_class = Return of value_class | Failure | Error | Exception
+
+  val yojson_of_return_class : return_class -> Yojson.Safe.t
+
   val get_timing : t -> int
   (** Extracts the information about time consumption from an [ocamlmerlin]
       response *)
@@ -89,7 +94,7 @@ module Response : sig
   (** Removes the value field from the merlin response, i.e. the actual response
       to the query. *)
 
-  val is_successful : t -> bool
+  val get_return_class : t -> (return_class, Logs.t) result
 end
 
 module Cmd : sig

--- a/test/bench.t/run.t
+++ b/test/bench.t/run.t
@@ -75,73 +75,7 @@
     ]
   }
 
-  $ cat test-data/bench.json |
-  > jq '.results |= map( .metrics |= map(.value |= map(0)))' |
-  > cb-check
-  Correctly parsed some benchmarks:
-  {
-    "name": null,
-    "results": [
-      {
-        "name": "buffer-typed",
-        "metrics": [
-          {
-            "name": "case-analysis",
-            "description": "",
-            "value": [ 0.0, 0.0, 0.0, 0.0 ],
-            "units": "ms",
-            "trend": "",
-            "lines": []
-          },
-          {
-            "name": "complete-prefix",
-            "description": "",
-            "value": [ 0.0, 0.0, 0.0 ],
-            "units": "ms",
-            "trend": "",
-            "lines": []
-          },
-          {
-            "name": "errors",
-            "description": "",
-            "value": [ 0.0, 0.0 ],
-            "units": "ms",
-            "trend": "",
-            "lines": []
-          },
-          {
-            "name": "expand-prefix",
-            "description": "",
-            "value": [ 0.0, 0.0, 0.0 ],
-            "units": "ms",
-            "trend": "",
-            "lines": []
-          },
-          {
-            "name": "locate",
-            "description": "",
-            "value": [ 0.0, 0.0, 0.0 ],
-            "units": "ms",
-            "trend": "",
-            "lines": []
-          },
-          {
-            "name": "occurrences",
-            "description": "",
-            "value": [ 0.0, 0.0, 0.0 ],
-            "units": "ms",
-            "trend": "",
-            "lines": []
-          },
-          {
-            "name": "type-enclosing",
-            "description": "",
-            "value": [ 0.0, 0.0, 0.0, 0.0 ],
-            "units": "ms",
-            "trend": "",
-            "lines": []
-          }
-        ]
-      }
-    ]
-  }
+(* FIXME: What's cb-check?)
+$ cat test-data/bench.json |
+> jq '.results |= map( .metrics |= map(.value |= map(0)))' |
+> cb-check

--- a/test/error_regression.t/run.t
+++ b/test/error_regression.t/run.t
@@ -1,17 +1,17 @@
-  $ merl-an error-regression -s 1 -p test.ml,test1.ml --data=test-data
+  $ merl-an behavior -s 1 -p test.ml,test1.ml --data=test-data
 
-  $ cat test-data/results.json
-  {"sample_id":13,"cmd":"ocamlmerlin server errors -filename test1.ml < test1.ml","success":true}
-  {"sample_id":12,"cmd":" ocamlmerlin server locate -look-for ml -position '3:12' -filename test1.ml < test1.ml","success":true}
-  {"sample_id":11,"cmd":"ocamlmerlin server expand-prefix -prefix '( +' -position '3:12' -filename test1.ml < test1.ml","success":true}
-  {"sample_id":10,"cmd":"ocamlmerlin server complete-prefix -prefix '( +' -position '3:12' -filename test1.ml < test1.ml","success":true}
-  {"sample_id":9,"cmd":"ocamlmerlin server occurrences -identifier-at '3:12' -filename test1.ml < test1.ml","success":true}
-  {"sample_id":8,"cmd":"ocamlmerlin server type-enclosing -position '1:8' -index 0 -filename test1.ml < test1.ml","success":true}
-  {"sample_id":7,"cmd":"ocamlmerlin server case-analysis -start '1:8' -end '1:8' -filename test1.ml < test1.ml","success":true}
-  {"sample_id":6,"cmd":"ocamlmerlin server errors -filename test.ml < test.ml","success":true}
-  {"sample_id":5,"cmd":" ocamlmerlin server locate -look-for ml -position '3:12' -filename test.ml < test.ml","success":true}
-  {"sample_id":4,"cmd":"ocamlmerlin server expand-prefix -prefix '( +' -position '3:12' -filename test.ml < test.ml","success":true}
-  {"sample_id":3,"cmd":"ocamlmerlin server complete-prefix -prefix '( +' -position '3:12' -filename test.ml < test.ml","success":true}
-  {"sample_id":2,"cmd":"ocamlmerlin server occurrences -identifier-at '3:12' -filename test.ml < test.ml","success":true}
-  {"sample_id":1,"cmd":"ocamlmerlin server type-enclosing -position '3:12' -index 0 -filename test.ml < test.ml","success":true}
-  {"sample_id":0,"cmd":"ocamlmerlin server case-analysis -start '3:14' -end '3:14' -filename test.ml < test.ml","success":true}
+  $ cat test-data/return_classes.json
+  {"sample_id":13,"return":["Return",["Other"]],"cmd":"ocamlmerlin server errors -filename test1.ml < test1.ml"}
+  {"sample_id":12,"return":["Return",["Other"]],"cmd":" ocamlmerlin server locate -look-for ml -position '3:12' -filename test1.ml < test1.ml"}
+  {"sample_id":11,"return":["Return",["Other"]],"cmd":"ocamlmerlin server expand-prefix -prefix '( +' -position '3:12' -filename test1.ml < test1.ml"}
+  {"sample_id":10,"return":["Return",["Other"]],"cmd":"ocamlmerlin server complete-prefix -prefix '( +' -position '3:12' -filename test1.ml < test1.ml"}
+  {"sample_id":9,"return":["Return",["Other"]],"cmd":"ocamlmerlin server occurrences -identifier-at '3:12' -filename test1.ml < test1.ml"}
+  {"sample_id":8,"return":["Return",["Other"]],"cmd":"ocamlmerlin server type-enclosing -position '1:8' -index 0 -filename test1.ml < test1.ml"}
+  {"sample_id":7,"return":["Return",["Other"]],"cmd":"ocamlmerlin server case-analysis -start '1:8' -end '1:8' -filename test1.ml < test1.ml"}
+  {"sample_id":6,"return":["Return",["Other"]],"cmd":"ocamlmerlin server errors -filename test.ml < test.ml"}
+  {"sample_id":5,"return":["Return",["Other"]],"cmd":" ocamlmerlin server locate -look-for ml -position '3:12' -filename test.ml < test.ml"}
+  {"sample_id":4,"return":["Return",["Other"]],"cmd":"ocamlmerlin server expand-prefix -prefix '( +' -position '3:12' -filename test.ml < test.ml"}
+  {"sample_id":3,"return":["Return",["Other"]],"cmd":"ocamlmerlin server complete-prefix -prefix '( +' -position '3:12' -filename test.ml < test.ml"}
+  {"sample_id":2,"return":["Return",["Other"]],"cmd":"ocamlmerlin server occurrences -identifier-at '3:12' -filename test.ml < test.ml"}
+  {"sample_id":1,"return":["Return",["Other"]],"cmd":"ocamlmerlin server type-enclosing -position '3:12' -index 0 -filename test.ml < test.ml"}
+  {"sample_id":0,"return":["Return",["Other"]],"cmd":"ocamlmerlin server case-analysis -start '3:14' -end '3:14' -filename test.ml < test.ml"}

--- a/test/perf.t/run.t
+++ b/test/perf.t/run.t
@@ -27,9 +27,9 @@
   > | .typer |= 0
   > | .error |= 0)
   > )'
-  {"sample_id":6,"responses":[{"class":"return","notifications":[],"timing":{"clock":0,"cpu":0,"query":0,"pp":0,"reader":0,"ppx":0,"typer":0,"error":0}}],"merlin_id":1}
-  {"sample_id":6,"responses":[{"class":"return","notifications":[],"timing":{"clock":0,"cpu":0,"query":0,"pp":0,"reader":0,"ppx":0,"typer":0,"error":0}}],"merlin_id":0}
-  {"sample_id":1,"responses":[{"class":"return","notifications":[],"timing":{"clock":0,"cpu":0,"query":0,"pp":0,"reader":0,"ppx":0,"typer":0,"error":0}}],"merlin_id":1}
-  {"sample_id":1,"responses":[{"class":"return","notifications":[],"timing":{"clock":0,"cpu":0,"query":0,"pp":0,"reader":0,"ppx":0,"typer":0,"error":0}}],"merlin_id":0}
-  {"sample_id":0,"responses":[{"class":"return","notifications":[],"timing":{"clock":0,"cpu":0,"query":0,"pp":0,"reader":0,"ppx":0,"typer":0,"error":0}}],"merlin_id":1}
-  {"sample_id":0,"responses":[{"class":"return","notifications":[],"timing":{"clock":0,"cpu":0,"query":0,"pp":0,"reader":0,"ppx":0,"typer":0,"error":0}}],"merlin_id":0}
+  {"sample_id":6,"responses":[{"class":"return","notifications":[],"timing":{"clock":0,"cpu":0,"query":0,"pp":0,"reader":0,"ppx":0,"typer":0,"error":0}}]}
+  {"sample_id":6,"responses":[{"class":"return","notifications":[],"timing":{"clock":0,"cpu":0,"query":0,"pp":0,"reader":0,"ppx":0,"typer":0,"error":0}}]}
+  {"sample_id":1,"responses":[{"class":"return","notifications":[],"timing":{"clock":0,"cpu":0,"query":0,"pp":0,"reader":0,"ppx":0,"typer":0,"error":0}}]}
+  {"sample_id":1,"responses":[{"class":"return","notifications":[],"timing":{"clock":0,"cpu":0,"query":0,"pp":0,"reader":0,"ppx":0,"typer":0,"error":0}}]}
+  {"sample_id":0,"responses":[{"class":"return","notifications":[],"timing":{"clock":0,"cpu":0,"query":0,"pp":0,"reader":0,"ppx":0,"typer":0,"error":0}}]}
+  {"sample_id":0,"responses":[{"class":"return","notifications":[],"timing":{"clock":0,"cpu":0,"query":0,"pp":0,"reader":0,"ppx":0,"typer":0,"error":0}}]}


### PR DESCRIPTION
The commit contains a few changes to improve the [behavior] cmd:
- Changes the `error-regression` (now called `return-classes`) design: It's integrated into the `behavior` cmd instead of an own cmd.
- Improves the output of `return-classes`: It's now finer-grained by con- taining
`Return of (Msg of string | Empty | Other) | Failure | Error | Exception`. Before, it contained the boolean "is `Return`"
- Removes the `merlin-id` from the full-behavior output