### PR TITLE
Allow only one Merlin version

### DIFF
--- a/bin/args.ml
+++ b/bin/args.ml
@@ -28,18 +28,15 @@ let dir_name =
     (fun x -> `Dir_name x)
     Arg.(value & opt (some string) None & info [ "data" ] ~doc)
 
-let cache_workflows =
+let cache_workflow =
   let doc =
     "This tool supports different workflows simulating different states of the \
-     [ocamlmerlin] cache. The option [warm] simulates the situation of a cache \
-     that's initialized in terms of [cmi]-files, but not in terms of \
-     [cmt]-files: it uses the merlin server frontend and only initializes the \
-     cache via a general command using [cmt]-files. The option [freezing] \
-     simulates the situation of opening a new project and running a merlin \
-     query for the first time: it uses the single frontend.\n\
-     By default, this tool gathers data for the three workflows. You can \
-     restrict to less workflows via this option.\n\
-    \    "
+     [ocamlmerlin] cache. The option [bufer-typed] simulates the situation of \
+     using Merlin on a fully typed buffer: the cache of the current typing as \
+     well as the cmi-cache are warm; the cmt-cache is unpredictable. The \
+     option [no-cache] simulates the situation of opening a new project and \
+     running a merlin query for the very first time: it uses the single \
+     frontend."
     (*TODO: Add: The option [hot] simulates the situation of having a \
       fully initialized cache: it uses the merlin server frontend and \
       initializes the cache 100%.*)
@@ -54,7 +51,7 @@ let cache_workflows =
     (fun x -> `Cache x)
     Arg.(
       value
-      & opt (list e) Merl_an.Merlin.Cache_workflow.all
+      & opt e Merl_an.Merlin.Cache_workflow.Buffer_typed
       & info [ "cache" ] ~doc)
 
 let sample_size =

--- a/bin/args.mli
+++ b/bin/args.mli
@@ -12,15 +12,13 @@ val dir_name : [> `Dir_name of string option ] Term.t
     exist, it's created. If the same directory was already used in the past, the
     data will be overridden. Defaults to [data/<project>+<unix_timestamp>/].*)
 
-val cache_workflows : [> `Cache of Merl_an.Merlin.Cache_workflow.t list ] Term.t
+val cache_workflow : [> `Cache of Merl_an.Merlin.Cache_workflow.t ] Term.t
 (** This tool supports different workflows simulating different states of the
-    [ocamlmerlin] cache. The option [warm] simulates the situation of a cache
-    that's initialized in terms of [cmi]-files, but not in terms of [cmt]-files:
-    it uses the merlin server frontend and only initializes the cache via a
-    general command using [cmt]-files. The option [freezing] simulates the
-    situation of opening a new project and running a merlin query for the first
-    time: it uses the single frontend. By default, this tool gathers data for
-    the three workflows. You can restrict to less workflows via this option. *)
+    [ocamlmerlin] cache. The option [bufer-typed] simulates the situation of
+    using Merlin on a fully typed buffer: the cache of the current typing as
+    well as the cmi-cache are warm; the cmt-cache is unpredictable. The option
+    [no-cache] simulates the situation of opening a new project and running a
+    merlin query for the very first time: it uses the single frontend. *)
 (* TODO: Add: The option [hot] simulates the situation of having a
     fully initialized cache: it uses the merlin server frontend and initializes
     the cache 100%.*)

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -11,12 +11,12 @@ let man =
        dumped into json-line files.";
   ]
 
-let analyze ~backend (`Repeats repeats) (`Cache cache_workflows)
+let analyze ~backend (`Repeats repeats) (`Cache cache_workflow)
     (`Merlin merlin_path) (`Proj_dirs proj_dirs) (`Dir_name data_dir)
     (`Sample_size sample_size) (`Query_types query_types)
     (`Extensions extensions) =
   match
-    Merl_an.Workflows.analyze ~backend ~repeats ~cache_workflows ~merlin_path
+    Merl_an.Workflows.analyze ~backend ~repeats ~cache_workflow ~merlin_path
       ~proj_dirs ~data_dir ~sample_size ~query_types ~extensions
   with
   | Ok () -> ()
@@ -30,7 +30,7 @@ let performance_term =
   in
   Term.(
     const (analyze ~backend)
-    $ Args.repeats_per_sample $ Args.cache_workflows $ Args.merlin
+    $ Args.repeats_per_sample $ Args.cache_workflow $ Args.merlin
     $ Args.proj_dirs $ Args.dir_name $ Args.sample_size $ Args.query_types
     $ Args.extensions)
 
@@ -51,7 +51,7 @@ let behavior =
     in
     let backend = Merl_an.Backend.behavior config in
     analyze ~backend (`Repeats 1)
-      (`Cache [ Merl_an.Merlin.Cache_workflow.Buffer_typed ])
+      (`Cache Merl_an.Merlin.Cache_workflow.Buffer_typed)
   in
   let pre_term = Term.(const f $ Args.no_full $ Args.no_cat_data) in
   let behavior_term =
@@ -80,7 +80,7 @@ let benchmark =
     Term.(
       const
         (analyze ~backend (`Repeats 1)
-           (`Cache [ Merl_an.Merlin.Cache_workflow.Buffer_typed ]))
+           (`Cache Merl_an.Merlin.Cache_workflow.Buffer_typed))
       $ Args.merlin $ Args.proj_dirs $ Args.dir_name $ Args.sample_size
       $ Args.query_types $ Args.extensions)
   in

--- a/lib/backend.mli
+++ b/lib/backend.mli
@@ -11,7 +11,7 @@ module type Data_tables = sig
   val kind : kind
   (** The backend kind *)
 
-  val create_initial : Merlin.t list -> t
+  val create_initial : Merlin.t -> t
   (** Initializes the tables. Data can then be appended to them. *)
 
   val update_analysis_data :
@@ -20,7 +20,6 @@ module type Data_tables = sig
     cmd:Merlin.Cmd.t ->
     file:File.t ->
     loc:Location.t ->
-    merlin_id:int ->
     query_type:Merlin.Query_type.t ->
     t ->
     unit
@@ -35,7 +34,8 @@ module type Data_tables = sig
   val all_files : unit -> Fpath.t list
   (** Returns the list of all files to which the data is dumped with [dump]. *)
 
-  val wrap_up : t -> dump_dir:Fpath.t -> proj_paths:Fpath.t list -> unit
+  val wrap_up :
+    t -> dump_dir:Fpath.t -> proj_paths:Fpath.t list -> merlin:Merlin.t -> unit
   (** Call this, before ending the program. It makes sure there's no data left
       in memory anymore and, in case there still is, dumps it (TODO!). Depending
       on the backend kind, it also generates and dumps some metadata. *)

--- a/lib/data.mli
+++ b/lib/data.mli
@@ -7,7 +7,6 @@ type sample = {
   cmd : Merlin.Cmd.t;
   file : File.t;
   loc : Location.t;
-  merlin_id : int;
   query_type : Merlin.Query_type.t;
 }
 
@@ -19,7 +18,7 @@ module Make (Backend : Backend.Data_tables) : sig
       (mutable). *)
 
   (* TODO: this shouldn't be only exactly merlins and dump_dir, but all configuration data. and the data should be stored in Data.t as well*)
-  val init : Merlin.t list -> Fpath.t -> t
+  val init : Merlin.t -> Fpath.t -> t
   (** [init ~pure dir_path] returns a data instance with empty mutable content.
       The provided path [dir_path] is the path of the directory, inside which
       the data will be persisted as json-line-files. *)

--- a/lib/merlin.ml
+++ b/lib/merlin.ml
@@ -41,7 +41,6 @@ module Path = struct
 end
 
 type t = {
-  id : int;
   path : Path.t;
   cache_workflow : Cache_workflow.t;
   version : Yojson.Safe.t;
@@ -52,7 +51,6 @@ type t = {
 let pp ppf merlin =
   Format.fprintf ppf "%s%!" (Yojson.Safe.to_string (yojson_of_t merlin))
 
-let get_id m = m.id
 let is_server merlin = Cache_workflow.uses_server merlin.cache_workflow
 
 let basic_cmd ppf { path; cache_workflow; _ } =
@@ -86,12 +84,12 @@ let untimed_query_str cmd =
   let f = input_line in
   untimed_query_generic ~f cmd
 
-let make id ?comment path cache_workflow =
+let make ?comment path cache_workflow =
   let cmd =
     Printf.sprintf "%s -version" (Cache_workflow.print path cache_workflow)
   in
   let version = `String (untimed_query_str cmd) in
-  { id; path; cache_workflow; version; comment }
+  { path; cache_workflow; version; comment }
 
 module Query_type = struct
   type t =

--- a/lib/merlin.mli
+++ b/lib/merlin.mli
@@ -23,13 +23,10 @@ type t
 val pp : Format.formatter -> t -> unit
 val yojson_of_t : t -> Yojson.Safe.t
 
-val make : int -> ?comment:string -> Fpath.t -> Cache_workflow.t -> t
+val make : ?comment:string -> Fpath.t -> Cache_workflow.t -> t
 (** Create a [t] value by providing the path of where your [ocamlmerlin]
     executable lives and the frontend you want to be used and the id you want to
     attach to it. *)
-
-val get_id : t -> int
-(** Get the idea of your merlin instance *)
 
 val is_server : t -> bool
 (** Returns [true] if the frontend is [Server] and [false] if it's [Single] *)

--- a/lib/samples.mli
+++ b/lib/samples.mli
@@ -18,7 +18,7 @@ val generate :
     sample set together with an updated [id_counter]. *)
 
 val analyze :
-  merlins:Merlin.t list ->
+  merlin:Merlin.t ->
   repeats:int ->
   update:(Data.sample -> unit) ->
   t ->

--- a/lib/workflows.ml
+++ b/lib/workflows.ml
@@ -1,12 +1,10 @@
 open! Import
 
 let analyze ~backend:(module Backend : Backend.Data_tables) ~repeats
-    ~cache_workflows ~merlin_path ~proj_dirs ~data_dir ~sample_size ~query_types
+    ~cache_workflow ~merlin_path ~proj_dirs ~data_dir ~sample_size ~query_types
     ~extensions =
   let merlin_path = Fpath.v merlin_path in
-  let merlins =
-    List.mapi (fun i -> Merlin.make i merlin_path) cache_workflows
-  in
+  let merlin = Merlin.make merlin_path cache_workflow in
   let proj_path dir = Fpath.v @@ dir in
   let open Result.Syntax in
   let* data_dir =
@@ -27,7 +25,7 @@ let analyze ~backend:(module Backend : Backend.Data_tables) ~repeats
         Fpath.v ("data/" ^ proj_name ^ "+" ^ ts)
   in
   let module D = Data.Make (Backend) in
-  let data = D.init merlins data_dir in
+  let data = D.init merlin data_dir in
   let proj_paths = List.map proj_path proj_dirs in
   let* files = File.get_files ~extensions proj_paths in
   (*TODO: add terminal logging when getting the files: log number of files that are going to be benchmarked and, at the end, log how many that are.*)
@@ -35,28 +33,23 @@ let analyze ~backend:(module Backend : Backend.Data_tables) ~repeats
     let update = D.update data in
     if Merlin.Query_type.is_global query_type then
       let () =
-        List.iter
-          (fun merlin ->
-            let d =
-              let* cmd = Merlin.Cmd.make ~query_type ~file merlin in
-              let* responses = Merlin.Cmd.run ~repeats cmd in
-              Ok (cmd, responses)
-            in
-            match d with
-            | Error log -> D.persist_logs ~log data
-            | Ok (cmd, responses) ->
-                let merlin_id = Merlin.get_id merlin in
-                update
-                  {
-                    Data.id = id_counter;
-                    responses;
-                    cmd;
-                    file;
-                    loc = Location.none;
-                    query_type;
-                    merlin_id;
-                  })
-          merlins
+        let d =
+          let* cmd = Merlin.Cmd.make ~query_type ~file merlin in
+          let* responses = Merlin.Cmd.run ~repeats cmd in
+          Ok (cmd, responses)
+        in
+        match d with
+        | Error log -> D.persist_logs ~log data
+        | Ok (cmd, responses) ->
+            update
+              {
+                Data.id = id_counter;
+                responses;
+                cmd;
+                file;
+                loc = Location.none;
+                query_type;
+              }
       in
       id_counter + 1
     else
@@ -70,7 +63,7 @@ let analyze ~backend:(module Backend : Backend.Data_tables) ~repeats
           D.persist_logs ~log data;
           id_counter
       | Some (samples, new_id_counter) -> (
-          match Samples.analyze ~merlins ~repeats ~update samples with
+          match Samples.analyze ~merlin ~repeats ~update samples with
           | Ok () -> new_id_counter
           | Error log ->
               D.persist_logs ~log data;
@@ -82,7 +75,5 @@ let analyze ~backend:(module Backend : Backend.Data_tables) ~repeats
   in
   D.dump data;
   D.wrap_up data ~proj_paths;
-  (match List.find_opt Merlin.is_server merlins with
-  | Some merlin -> Merlin.stop_server merlin
-  | None -> ());
+  if Merlin.is_server merlin then Merlin.stop_server merlin else ();
   Ok ()

--- a/lib/workflows.mli
+++ b/lib/workflows.mli
@@ -3,7 +3,7 @@ open! Import
 val analyze :
   backend:(module Backend.Data_tables) ->
   repeats:int ->
-  cache_workflows:Merlin.Cache_workflow.t list ->
+  cache_workflow:Merlin.Cache_workflow.t ->
   merlin_path:string ->
   proj_dirs:string list ->
   data_dir:string option ->

--- a/test/perf.t/run.t
+++ b/test/perf.t/run.t
@@ -3,20 +3,14 @@
   $ cat test-data/performances.json |
   > jq -c '.timings |= 0
   > | .max_timing |= 0'
-  {"sample_id":6,"timings":0,"max_timing":0,"file":"files/nested-dir/perf.ml","merlin_id":1,"query_type":["Errors"],"loc":"File \"_none_\", line 1, characters -1--1:"}
-  {"sample_id":6,"timings":0,"max_timing":0,"file":"files/nested-dir/perf.ml","merlin_id":0,"query_type":["Errors"],"loc":"File \"_none_\", line 1, characters -1--1:"}
-  {"sample_id":1,"timings":0,"max_timing":0,"file":"files/nested-dir/perf.ml","merlin_id":1,"query_type":["Type_enclosing"],"loc":"File \"files/nested-dir/perf.ml\", line 1, characters 8-9:"}
-  {"sample_id":1,"timings":0,"max_timing":0,"file":"files/nested-dir/perf.ml","merlin_id":0,"query_type":["Type_enclosing"],"loc":"File \"files/nested-dir/perf.ml\", line 1, characters 8-9:"}
-  {"sample_id":0,"timings":0,"max_timing":0,"file":"files/nested-dir/perf.ml","merlin_id":1,"query_type":["Case_analysis"],"loc":"File \"files/nested-dir/perf.ml\", line 1, characters 8-9:"}
-  {"sample_id":0,"timings":0,"max_timing":0,"file":"files/nested-dir/perf.ml","merlin_id":0,"query_type":["Case_analysis"],"loc":"File \"files/nested-dir/perf.ml\", line 1, characters 8-9:"}
+  {"sample_id":6,"timings":0,"max_timing":0,"file":"files/nested-dir/perf.ml","query_type":["Errors"],"loc":"File \"_none_\", line 1, characters -1--1:"}
+  {"sample_id":1,"timings":0,"max_timing":0,"file":"files/nested-dir/perf.ml","query_type":["Type_enclosing"],"loc":"File \"files/nested-dir/perf.ml\", line 1, characters 8-9:"}
+  {"sample_id":0,"timings":0,"max_timing":0,"file":"files/nested-dir/perf.ml","query_type":["Case_analysis"],"loc":"File \"files/nested-dir/perf.ml\", line 1, characters 8-9:"}
 
   $ cat test-data/commands.json
-  {"sample_id":6,"cmd":"ocamlmerlin single errors -filename files/nested-dir/perf.ml < files/nested-dir/perf.ml","merlin_id":1}
-  {"sample_id":6,"cmd":"ocamlmerlin server errors -filename files/nested-dir/perf.ml < files/nested-dir/perf.ml","merlin_id":0}
-  {"sample_id":1,"cmd":"ocamlmerlin single type-enclosing -position '1:8' -index 0 -filename files/nested-dir/perf.ml < files/nested-dir/perf.ml","merlin_id":1}
-  {"sample_id":1,"cmd":"ocamlmerlin server type-enclosing -position '1:8' -index 0 -filename files/nested-dir/perf.ml < files/nested-dir/perf.ml","merlin_id":0}
-  {"sample_id":0,"cmd":"ocamlmerlin single case-analysis -start '1:8' -end '1:8' -filename files/nested-dir/perf.ml < files/nested-dir/perf.ml","merlin_id":1}
-  {"sample_id":0,"cmd":"ocamlmerlin server case-analysis -start '1:8' -end '1:8' -filename files/nested-dir/perf.ml < files/nested-dir/perf.ml","merlin_id":0}
+  {"sample_id":6,"cmd":"ocamlmerlin server errors -filename files/nested-dir/perf.ml < files/nested-dir/perf.ml"}
+  {"sample_id":1,"cmd":"ocamlmerlin server type-enclosing -position '1:8' -index 0 -filename files/nested-dir/perf.ml < files/nested-dir/perf.ml"}
+  {"sample_id":0,"cmd":"ocamlmerlin server case-analysis -start '1:8' -end '1:8' -filename files/nested-dir/perf.ml < files/nested-dir/perf.ml"}
 
   $ cat test-data/query_responses.json |
   > jq -c '.responses |= map (.timing |=
@@ -27,9 +21,6 @@
   > | .typer |= 0
   > | .error |= 0)
   > )'
-  {"sample_id":6,"responses":[{"class":"return","notifications":[],"timing":{"clock":0,"cpu":0,"query":0,"pp":0,"reader":0,"ppx":0,"typer":0,"error":0},"query_num":0}]}
   {"sample_id":6,"responses":[{"class":"return","notifications":[],"timing":{"clock":0,"cpu":0,"query":0,"pp":0,"reader":0,"ppx":0,"typer":0,"error":0},"query_num":4}]}
-  {"sample_id":1,"responses":[{"class":"return","notifications":[],"timing":{"clock":0,"cpu":0,"query":0,"pp":0,"reader":0,"ppx":0,"typer":0,"error":0},"query_num":0}]}
   {"sample_id":1,"responses":[{"class":"return","notifications":[],"timing":{"clock":0,"cpu":0,"query":0,"pp":0,"reader":0,"ppx":0,"typer":0,"error":0},"query_num":3}]}
-  {"sample_id":0,"responses":[{"class":"return","notifications":[],"timing":{"clock":0,"cpu":0,"query":0,"pp":0,"reader":0,"ppx":0,"typer":0,"error":0},"query_num":0}]}
   {"sample_id":0,"responses":[{"class":"return","notifications":[],"timing":{"clock":0,"cpu":0,"query":0,"pp":0,"reader":0,"ppx":0,"typer":0,"error":0},"query_num":1}]}


### PR DESCRIPTION
Before, [merl-an] could be fed different Merlin versions or Merlin frontends (i.e. [single] or [server]) and [merl-an] would run all queries for all fed Merlin versions/frontends. That can be useful for the [performance] cmd. However, it's unnecessary noise for other commands and makes the code harder to refactor.

This commit removes that feature. With it, [merl-an] runs the query on exactly one Merlin version and frontend.