### PR TITLE
Improve perf

### DIFF
--- a/lib/backend.ml
+++ b/lib/backend.ml
@@ -7,6 +7,7 @@ module type Data_tables = sig
 
   val kind : kind
   val create_initial : Merlin.t -> t
+  val init_cache : t -> bool
 
   val update_analysis_data :
     id:int ->
@@ -236,6 +237,7 @@ module Performance = struct
   }
   [@@deriving fields]
 
+  let init_cache p = Merlin.is_server p.merlin
   let kind = Perf
 
   let dump ~dump_dir t =
@@ -409,6 +411,8 @@ let behavior config =
       (* TODO: check whether there's data left in memory and, if so, dump it *)
       ()
 
+    let init_cache _ = false
+
     let all_files () =
       let f = Field.to_filename in
       Fields.to_list ~full_responses:f ~category_data:f ~commands:f ~logs:f
@@ -426,6 +430,7 @@ module Benchmark = struct
   [@@deriving fields]
 
   let kind = Bench
+  let init_cache b = Merlin.is_server b.merlin
 
   let create_initial merlin =
     {

--- a/lib/backend.mli
+++ b/lib/backend.mli
@@ -14,6 +14,8 @@ module type Data_tables = sig
   val create_initial : Merlin.t -> t
   (** Initializes the tables. Data can then be appended to them. *)
 
+  val init_cache : t -> bool
+
   val update_analysis_data :
     id:int ->
     responses:Merlin.Response.t list ->

--- a/lib/data.ml
+++ b/lib/data.ml
@@ -35,6 +35,8 @@ module Make (B : Backend.Data_tables) = struct
       Fpath.segs data_path |> List.rev |> get_all_subpaths []
       |> List.iter (fun dir -> try Sys.mkdir dir 0o777 with _ -> ())
 
+  let init_cache d = B.init_cache d.content
+
   let create_files dir =
     List.iter (fun fn ->
         let path = Fpath.(to_string @@ append dir fn) in

--- a/lib/data.mli
+++ b/lib/data.mli
@@ -23,6 +23,8 @@ module Make (Backend : Backend.Data_tables) : sig
       The provided path [dir_path] is the path of the directory, inside which
       the data will be persisted as json-line-files. *)
 
+  val init_cache : t -> bool
+
   val update : t -> sample -> unit
   (** Update the data by appending analyzis data of one sample to it. *)
 

--- a/lib/import.mli
+++ b/lib/import.mli
@@ -14,6 +14,7 @@ module List : sig
 
   val fold_over_product :
     l1:'a t -> l2:'b t -> init:'c -> ('c -> 'a * 'b -> 'c) -> 'c
+  (** The outer traversal is done over [l1], the inner traversal over [l2]. *)
 
   val is_empty : 'a t -> bool
 end

--- a/lib/samples.ml
+++ b/lib/samples.ml
@@ -76,7 +76,7 @@ let generate ~sample_size ~id_counter file query_type =
       in
       Some ({ samples; file; query_type }, id_counter + sample_size)
 
-let analyze ~merlin ~repeats ~update { samples; file; query_type } =
+let analyze ~init_cache ~merlin ~repeats ~update { samples; file; query_type } =
   let open Result.Syntax in
   if List.is_empty samples then
     Error
@@ -85,9 +85,7 @@ let analyze ~merlin ~repeats ~update { samples; file; query_type } =
             (Yojson.Safe.to_string @@ File.yojson_of_t file)
             (Merlin.Query_type.to_string query_type)))
   else
-    let* () =
-      if Merlin.is_server merlin then Merlin.init_cache file merlin else Ok ()
-    in
+    let* () = if init_cache then Merlin.init_cache file merlin else Ok () in
     let rec loop samples =
       match samples with
       | [] -> Ok ()

--- a/lib/samples.mli
+++ b/lib/samples.mli
@@ -18,6 +18,7 @@ val generate :
     sample set together with an updated [id_counter]. *)
 
 val analyze :
+  init_cache:bool ->
   merlin:Merlin.t ->
   repeats:int ->
   update:(Data.sample -> unit) ->

--- a/lib/workflows.ml
+++ b/lib/workflows.ml
@@ -73,6 +73,7 @@ let analyze ~backend:(module Backend : Backend.Data_tables) ~repeats
               new_id_counter)
   in
   let _last_sample_id =
+    (* The traversal is done in files -> query_types order. *)
     List.fold_over_product ~l1:files ~l2:query_types ~init:0
       side_effectively_add_data
   in

--- a/lib/workflows.ml
+++ b/lib/workflows.ml
@@ -26,6 +26,7 @@ let analyze ~backend:(module Backend : Backend.Data_tables) ~repeats
   in
   let module D = Data.Make (Backend) in
   let data = D.init merlin data_dir in
+  let init_cache = D.init_cache data in
   let proj_paths = List.map proj_path proj_dirs in
   let* files = File.get_files ~extensions proj_paths in
   (*TODO: add terminal logging when getting the files: log number of files that are going to be benchmarked and, at the end, log how many that are.*)
@@ -63,7 +64,9 @@ let analyze ~backend:(module Backend : Backend.Data_tables) ~repeats
           D.persist_logs ~log data;
           id_counter
       | Some (samples, new_id_counter) -> (
-          match Samples.analyze ~merlin ~repeats ~update samples with
+          match
+            Samples.analyze ~init_cache ~merlin ~repeats ~update samples
+          with
           | Ok () -> new_id_counter
           | Error log ->
               D.persist_logs ~log data;

--- a/test/behavior.t/run.t
+++ b/test/behavior.t/run.t
@@ -1,30 +1,30 @@
   $ merl-an behavior -s 1 -p test.ml,test1.ml --data=test-data
 
   $ cat test-data/category_data.json
-  {"sample_id":13,"return":["Return",["Other"]],"query_num":25,"cmd":"ocamlmerlin server errors -filename test1.ml < test1.ml"}
-  {"sample_id":12,"return":["Return",["Other"]],"query_num":24,"cmd":" ocamlmerlin server locate -look-for ml -position '3:12' -filename test1.ml < test1.ml"}
-  {"sample_id":11,"return":["Return",["Other"]],"query_num":22,"cmd":"ocamlmerlin server expand-prefix -prefix '( +' -position '3:12' -filename test1.ml < test1.ml"}
-  {"sample_id":10,"return":["Return",["Other"]],"query_num":20,"cmd":"ocamlmerlin server complete-prefix -prefix '( +' -position '3:12' -filename test1.ml < test1.ml"}
-  {"sample_id":9,"return":["Return",["Other"]],"query_num":18,"cmd":"ocamlmerlin server occurrences -identifier-at '3:12' -filename test1.ml < test1.ml"}
-  {"sample_id":8,"return":["Return",["Other"]],"query_num":16,"cmd":"ocamlmerlin server type-enclosing -position '1:8' -index 0 -filename test1.ml < test1.ml"}
-  {"sample_id":7,"return":["Return",["Other"]],"query_num":14,"cmd":"ocamlmerlin server case-analysis -start '1:8' -end '1:8' -filename test1.ml < test1.ml"}
-  {"sample_id":6,"return":["Return",["Other"]],"query_num":12,"cmd":"ocamlmerlin server errors -filename test.ml < test.ml"}
-  {"sample_id":5,"return":["Return",["Other"]],"query_num":11,"cmd":" ocamlmerlin server locate -look-for ml -position '3:12' -filename test.ml < test.ml"}
-  {"sample_id":4,"return":["Return",["Other"]],"query_num":9,"cmd":"ocamlmerlin server expand-prefix -prefix '( +' -position '3:12' -filename test.ml < test.ml"}
-  {"sample_id":3,"return":["Return",["Other"]],"query_num":7,"cmd":"ocamlmerlin server complete-prefix -prefix '( +' -position '3:12' -filename test.ml < test.ml"}
-  {"sample_id":2,"return":["Return",["Other"]],"query_num":5,"cmd":"ocamlmerlin server occurrences -identifier-at '3:12' -filename test.ml < test.ml"}
-  {"sample_id":1,"return":["Return",["Other"]],"query_num":3,"cmd":"ocamlmerlin server type-enclosing -position '3:12' -index 0 -filename test.ml < test.ml"}
-  {"sample_id":0,"return":["Return",["Other"]],"query_num":1,"cmd":"ocamlmerlin server case-analysis -start '3:14' -end '3:14' -filename test.ml < test.ml"}
+  {"sample_id":13,"return":["Return",["Other"]],"query_num":13,"cmd":"ocamlmerlin server errors -filename test1.ml < test1.ml"}
+  {"sample_id":12,"return":["Return",["Other"]],"query_num":12,"cmd":" ocamlmerlin server locate -look-for ml -position '3:12' -filename test1.ml < test1.ml"}
+  {"sample_id":11,"return":["Return",["Other"]],"query_num":11,"cmd":"ocamlmerlin server expand-prefix -prefix '( +' -position '3:12' -filename test1.ml < test1.ml"}
+  {"sample_id":10,"return":["Return",["Other"]],"query_num":10,"cmd":"ocamlmerlin server complete-prefix -prefix '( +' -position '3:12' -filename test1.ml < test1.ml"}
+  {"sample_id":9,"return":["Return",["Other"]],"query_num":9,"cmd":"ocamlmerlin server occurrences -identifier-at '3:12' -filename test1.ml < test1.ml"}
+  {"sample_id":8,"return":["Return",["Other"]],"query_num":8,"cmd":"ocamlmerlin server type-enclosing -position '1:8' -index 0 -filename test1.ml < test1.ml"}
+  {"sample_id":7,"return":["Return",["Other"]],"query_num":7,"cmd":"ocamlmerlin server case-analysis -start '1:8' -end '1:8' -filename test1.ml < test1.ml"}
+  {"sample_id":6,"return":["Return",["Other"]],"query_num":6,"cmd":"ocamlmerlin server errors -filename test.ml < test.ml"}
+  {"sample_id":5,"return":["Return",["Other"]],"query_num":5,"cmd":" ocamlmerlin server locate -look-for ml -position '3:12' -filename test.ml < test.ml"}
+  {"sample_id":4,"return":["Return",["Other"]],"query_num":4,"cmd":"ocamlmerlin server expand-prefix -prefix '( +' -position '3:12' -filename test.ml < test.ml"}
+  {"sample_id":3,"return":["Return",["Other"]],"query_num":3,"cmd":"ocamlmerlin server complete-prefix -prefix '( +' -position '3:12' -filename test.ml < test.ml"}
+  {"sample_id":2,"return":["Return",["Other"]],"query_num":2,"cmd":"ocamlmerlin server occurrences -identifier-at '3:12' -filename test.ml < test.ml"}
+  {"sample_id":1,"return":["Return",["Other"]],"query_num":1,"cmd":"ocamlmerlin server type-enclosing -position '3:12' -index 0 -filename test.ml < test.ml"}
+  {"sample_id":0,"return":["Return",["Other"]],"query_num":0,"cmd":"ocamlmerlin server case-analysis -start '3:14' -end '3:14' -filename test.ml < test.ml"}
 
 (* FIXME: This is a problem in all tests: The build artefacts aren't found.*)
   $ cat test-data/full_responses.json | sed "/No config found for file/d" | sed "/\"file\":/d"
-  {"sample_id":11,"responses":[{"class":"return","value":{"entries":[{"name":"()","kind":"Constructor","desc":"","info":"","deprecated":false}],"context":null},"notifications":[],"query_num":22}]}
-  {"sample_id":10,"responses":[{"class":"return","value":{"entries":[],"context":["application",{"argument_type":"'a","labels":[]}]},"notifications":[],"query_num":20}]}
-  {"sample_id":9,"responses":[{"class":"return","value":[{"start":{"line":3,"col":12},"end":{"line":3,"col":13}}],"notifications":[],"query_num":18}]}
-  {"sample_id":8,"responses":[{"class":"return","value":[{"start":{"line":1,"col":8},"end":{"line":1,"col":9},"type":"int","tail":"no"}],"notifications":[],"query_num":16}]}
-  {"sample_id":7,"responses":[{"class":"return","value":[{"start":{"line":1,"col":8},"end":{"line":1,"col":9}},"match 1 with | 0 -> _ | _ -> _"],"notifications":[],"query_num":14}]}
-  {"sample_id":4,"responses":[{"class":"return","value":{"entries":[{"name":"()","kind":"Constructor","desc":"","info":"","deprecated":false}],"context":null},"notifications":[],"query_num":9}]}
-  {"sample_id":3,"responses":[{"class":"return","value":{"entries":[],"context":["application",{"argument_type":"'a","labels":[]}]},"notifications":[],"query_num":7}]}
-  {"sample_id":2,"responses":[{"class":"return","value":[{"start":{"line":3,"col":12},"end":{"line":3,"col":13}}],"notifications":[],"query_num":5}]}
-  {"sample_id":1,"responses":[{"class":"return","value":[{"start":{"line":3,"col":12},"end":{"line":3,"col":13},"type":"int -> int -> int","tail":"no"},{"start":{"line":3,"col":10},"end":{"line":3,"col":15},"type":1,"tail":"no"},{"start":{"line":3,"col":6},"end":{"line":3,"col":15},"type":2,"tail":"no"}],"notifications":[],"query_num":3}]}
-  {"sample_id":0,"responses":[{"class":"return","value":[{"start":{"line":3,"col":14},"end":{"line":3,"col":15}},"(match 3 with | 0 -> _ | _ -> _)"],"notifications":[],"query_num":1}]}
+  {"sample_id":11,"responses":[{"class":"return","value":{"entries":[{"name":"()","kind":"Constructor","desc":"","info":"","deprecated":false}],"context":null},"notifications":[],"query_num":11}]}
+  {"sample_id":10,"responses":[{"class":"return","value":{"entries":[],"context":["application",{"argument_type":"'a","labels":[]}]},"notifications":[],"query_num":10}]}
+  {"sample_id":9,"responses":[{"class":"return","value":[{"start":{"line":3,"col":12},"end":{"line":3,"col":13}}],"notifications":[],"query_num":9}]}
+  {"sample_id":8,"responses":[{"class":"return","value":[{"start":{"line":1,"col":8},"end":{"line":1,"col":9},"type":"int","tail":"no"}],"notifications":[],"query_num":8}]}
+  {"sample_id":7,"responses":[{"class":"return","value":[{"start":{"line":1,"col":8},"end":{"line":1,"col":9}},"match 1 with | 0 -> _ | _ -> _"],"notifications":[],"query_num":7}]}
+  {"sample_id":4,"responses":[{"class":"return","value":{"entries":[{"name":"()","kind":"Constructor","desc":"","info":"","deprecated":false}],"context":null},"notifications":[],"query_num":4}]}
+  {"sample_id":3,"responses":[{"class":"return","value":{"entries":[],"context":["application",{"argument_type":"'a","labels":[]}]},"notifications":[],"query_num":3}]}
+  {"sample_id":2,"responses":[{"class":"return","value":[{"start":{"line":3,"col":12},"end":{"line":3,"col":13}}],"notifications":[],"query_num":2}]}
+  {"sample_id":1,"responses":[{"class":"return","value":[{"start":{"line":3,"col":12},"end":{"line":3,"col":13},"type":"int -> int -> int","tail":"no"},{"start":{"line":3,"col":10},"end":{"line":3,"col":15},"type":1,"tail":"no"},{"start":{"line":3,"col":6},"end":{"line":3,"col":15},"type":2,"tail":"no"}],"notifications":[],"query_num":1}]}
+  {"sample_id":0,"responses":[{"class":"return","value":[{"start":{"line":3,"col":14},"end":{"line":3,"col":15}},"(match 3 with | 0 -> _ | _ -> _)"],"notifications":[],"query_num":0}]}


### PR DESCRIPTION
There are two commits to improve the performance of the [behavior] cmd: one removes one unnecessary Merlin query per file and the other one is about the order of file-query traversal.