### PR TITLE
Print exception backtrace

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -24,7 +24,8 @@ let analyze ~backend (`Repeats repeats) (`Cache cache_workflow)
       Printf.eprintf "%s" err;
       exit 50
   | exception exc ->
-      Printf.eprintf "%s" @@ Printexc.to_string @@ exc;
+      Printf.eprintf "%s\n" @@ Printexc.to_string @@ exc;
+      Printf.eprintf "%s\n" @@ Printexc.get_backtrace @@ ();
       exit 100
 
 let performance_term =


### PR DESCRIPTION
What I really meant to do in #43 was print the backtrace, which is what I'm doing now.